### PR TITLE
Fix profiling warmup and NCCL synchronization

### DIFF
--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -1029,6 +1029,7 @@ void Matrix::compute_matvec(double *out_vec, double *in_vec, const MatvecConfig 
 
 #if TIME_MPI
     MPICHECK(MPI_Barrier(MPI_COMM_WORLD));
+    gpuErrchk(cudaDeviceSynchronize());
     (*tl)[ProfilerTimes::BROADCAST].stop();
 #endif
 
@@ -1233,6 +1234,7 @@ void Matrix::compute_matvec(double *out_vec, double *in_vec, const MatvecConfig 
         }
 
 #if TIME_MPI
+        gpuErrchk(cudaDeviceSynchronize());
         MPICHECK(MPI_Barrier(MPI_COMM_WORLD));
         (*tl)[ProfilerTimes::NCCLC].stop();
         (*tl)[ProfilerTimes::TOT].stop();
@@ -1272,6 +1274,7 @@ void Matrix::compute_matvec(double *out_vec, double *in_vec, const MatvecConfig 
         }
 
 #if TIME_MPI
+        gpuErrchk(cudaDeviceSynchronize());
         MPICHECK(MPI_Barrier(MPI_COMM_WORLD));
         (*tl)[ProfilerTimes::NCCLC].stop();
         (*tl)[ProfilerTimes::TOT].stop();
@@ -1457,6 +1460,7 @@ void Matrix::compute_matvec(double *out_vec, double *in_vec, const MatvecConfig 
         }
 
 #if TIME_MPI
+        gpuErrchk(cudaDeviceSynchronize());
         MPICHECK(MPI_Barrier(MPI_COMM_WORLD));
         (*tl2)[ProfilerTimes::NCCLC].stop();
         (*tl2)[ProfilerTimes::TOT].stop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,11 +269,22 @@ int main(int argc, char **argv)
 #endif
 
 #if TIME_MPI
+        for (int i = 0; i < WARMUP; i++)
+        {
+            F.matvec(in_F, out_F);
+            F.transpose_matvec(in_FS, out_FS);
+        }
+
+        for (auto &timer : t_list_f)
+            timer.clear();
+        for (auto &timer : t_list_fs)
+            timer.clear();
+
         MPICHECK(MPI_Barrier(MPI_COMM_WORLD));
         t_list[ProfilerTimesFull::FULL].start();
 #endif
         // Perform matrix-vector multiplication
-        for (int i = 0; i < reps + WARMUP; i++)
+        for (int i = 0; i < reps; i++)
         {
             F.matvec(in_F, out_F);
             F.transpose_matvec(in_FS, out_FS);


### PR DESCRIPTION
This fixes under-reporting in CPU-side profiling timers by synchronizing queued CUDA/NCCL work before stopping communication-stage timers.